### PR TITLE
Fix: use LLM_API_BASE for gito

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -22,9 +22,8 @@ jobs:
     - name: Run AI code analysis
       env:
         LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
-        LLM_API_TYPE: openai
-        LLM_BASE_URL: https://api.z.ai/api/coding/paas/v4
-        MODEL: glm-5
+        LLM_API_TYPE: anthropic
+        MODEL: claude-sonnet-4-5-20250929
         MAX_CONCURRENT_TASKS: 2
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         PR_NUMBER_FROM_WORKFLOW_DISPATCH: ${{ github.event.inputs.pr_number }}


### PR DESCRIPTION
gito uses ai-microcore which expects `LLM_API_BASE` not `LLM_BASE_URL`