### PR TITLE
feat(cli): add gw CLI tool for gateway interaction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,11 +95,18 @@ jobs:
       - name: Build release
         run: cargo build --release --verbose
 
-      - name: Upload gateway binary
+      - name: Upload gw-server binary
         uses: actions/upload-artifact@v4
         with:
-          name: gateway-binary
-          path: target/release/msg-gateway
+          name: gw-server-binary
+          path: target/release/gw-server
+          retention-days: 1
+
+      - name: Upload gw-cli binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: gw-cli-binary
+          path: target/release/gw-cli
           retention-days: 1
 
   e2e:
@@ -109,14 +116,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download gateway binary
+      - name: Download gw-server binary
         uses: actions/download-artifact@v4
         with:
-          name: gateway-binary
+          name: gw-server-binary
           path: target/release
 
       - name: Make binary executable
-        run: chmod +x target/release/msg-gateway
+        run: chmod +x target/release/gw-server
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,27 @@ User Protocols          Gateway              Backend Protocols
 - **Config hot reload**: File watcher detects changes and syncs adapter instances
 - **Health monitoring**: Buffers messages when backend is down, sends alerts
 
+## Project Structure
+
+This is a Cargo workspace with two crates:
+
+```
+msg-gateway/
+├── Cargo.toml              # Workspace root + gateway crate
+├── src/                    # Gateway binary + library
+└── crates/
+    └── gw-cli/             # CLI tool binary (`gw-cli`)
+        ├── Cargo.toml
+        └── src/
+            ├── main.rs     # clap entry point
+            ├── client.rs   # HTTP + WebSocket gateway client
+            ├── output.rs   # TTY-aware JSON/human formatter
+            └── commands/   # Subcommand implementations
+```
+
 ## Key Files
+
+### Gateway (`src/`)
 
 | File | Purpose |
 |------|---------|
@@ -43,11 +63,27 @@ User Protocols          Gateway              Backend Protocols
 | `src/admin.rs` | Admin API CRUD |
 | `src/error.rs` | Error types |
 
+### CLI Tool (`crates/gw-cli/`)
+
+| File | Purpose |
+|------|---------|
+| `src/main.rs` | clap CLI definition, subcommand routing |
+| `src/client.rs` | HTTP client for gateway API + WebSocket connection |
+| `src/output.rs` | TTY-aware output (JSON when piped, human-friendly on TTY) |
+| `src/commands/chat.rs` | Interactive REPL (WS receive + HTTP send loop) |
+| `src/commands/send.rs` | One-shot message send (--text or stdin) |
+| `src/commands/listen.rs` | WebSocket JSONL stream to stdout |
+| `src/commands/credentials.rs` | Admin CRUD for credentials |
+| `src/commands/health.rs` | Gateway health check |
+
 ## Common Commands
 
 ```bash
-# Build
+# Build everything (gateway + CLI)
 cargo build --release
+
+# Build just the CLI
+cargo build --release -p gw-cli
 
 # Run tests
 cargo test
@@ -55,14 +91,18 @@ cargo test
 # Run with coverage
 cargo llvm-cov
 
-# Lint
-cargo clippy -- -D warnings
+# Lint (workspace-wide)
+cargo clippy --all-targets --all-features -- -D warnings
 
-# Format
-cargo fmt
+# Format (workspace-wide)
+cargo fmt --all
 
-# Run the gateway
+# Run the gateway (binary: gw-server)
 GATEWAY_CONFIG=config.json cargo run
+
+# Run the CLI (binary: gw-cli)
+cargo run -p gw-cli -- --help
+cargo run -p gw-cli -- chat my_cred --chat-id test --token my-token
 ```
 
 ## Development Guidelines

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,6 +279,52 @@ dependencies = [
  "wasm-bindgen",
  "windows-link",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "core-foundation-sys"
@@ -522,6 +618,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "gw-cli"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "clap",
+ "futures-util",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-tungstenite 0.26.2",
+ "url",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,7 +741,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -854,6 +966,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
@@ -1160,6 +1278,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "parking_lot"
@@ -1482,7 +1606,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -1782,6 +1906,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1971,8 +2101,12 @@ checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
+ "rustls",
+ "rustls-pki-types",
  "tokio",
+ "tokio-rustls",
  "tungstenite 0.26.2",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -2127,6 +2261,8 @@ dependencies = [
  "httparse",
  "log",
  "rand",
+ "rustls",
+ "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
@@ -2202,6 +2338,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
@@ -2380,6 +2522,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[workspace]
+members = ["crates/gw-cli"]
+
 [package]
 name = "msg-gateway"
 version = "0.1.0"
@@ -8,7 +11,7 @@ name = "msg_gateway"
 path = "src/lib.rs"
 
 [[bin]]
-name = "msg-gateway"
+name = "gw-server"
 path = "src/main.rs"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ A standalone Rust message gateway that bridges user-facing communication protoco
 - **Health monitoring** — Emergency alerts when backend is unreachable
 - **Hot reload** — Config and guardrail changes apply without restart
 - **Admin API** — CRUD operations for credentials
+- **`gw-cli` CLI tool** — Unix-philosophy command-line client for chat, admin, and agent integration
 
 ## Quick Start
 
@@ -38,7 +39,7 @@ cp config.example.json config.json
 # Edit config.json with your credentials
 
 # Run
-GATEWAY_CONFIG=config.json ./target/release/msg-gateway
+GATEWAY_CONFIG=config.json ./target/release/gw-server
 ```
 
 ## Configuration
@@ -241,6 +242,59 @@ Point `guardrails_dir` at a directory of rule files:
 ```
 
 If `guardrails_dir` is omitted and a `guardrails/` directory exists next to `config.json`, it's picked up automatically.
+
+## CLI Tool (`gw-cli`)
+
+A standalone command-line client for interacting with the gateway. Supports interactive chat, one-shot messaging, WebSocket streaming, credential management, and health checks. Backend-agnostic — works with Pipelit, OpenCode, or any external backend.
+
+### Install
+
+```bash
+cargo build --release -p gw-cli
+# Binary at target/release/gw-cli
+```
+
+### Usage
+
+```bash
+# Set connection defaults
+export GATEWAY_URL=http://localhost:8080
+export GATEWAY_TOKEN=my-credential-token
+
+# Interactive chat REPL
+gw-cli chat my_credential --chat-id session-1
+
+# One-shot send (pipe-friendly)
+gw-cli send my_credential --chat-id session-1 --text "Hello"
+echo "Hello" | gw-cli send my_credential --chat-id session-1
+
+# Stream responses as JSONL (for agents, scripts, jq)
+gw-cli listen my_credential --chat-id session-1
+
+# Health check
+gw-cli health
+
+# Credential management (requires GATEWAY_ADMIN_TOKEN)
+gw-cli credentials list --admin-token my-admin-token
+gw-cli credentials create my_cred --adapter generic --token secret \
+  --backend pipelit --route '{"workflow_slug":"my-wf","trigger_node_id":"node_1"}'
+gw-cli credentials activate my_cred
+gw-cli credentials deactivate my_cred
+```
+
+### Output Modes
+
+- **TTY** (interactive terminal) — human-readable formatted output
+- **Piped** (stdout redirected) — auto-switches to JSON/JSONL
+- **`--json`** flag — force JSON output in any context
+
+### Environment Variables
+
+| Variable | Used by | Description |
+|----------|---------|-------------|
+| `GATEWAY_URL` | all commands | Gateway URL (default: `http://localhost:8080`) |
+| `GATEWAY_TOKEN` | chat, send, listen | Credential token for authentication |
+| `GATEWAY_ADMIN_TOKEN` | credentials, health | Admin token for management commands |
 
 ## API Endpoints
 

--- a/config.example.json
+++ b/config.example.json
@@ -50,8 +50,8 @@
       "active": true,
       "emergency": false,
       "route": {
-        "workflow_id": "wf_local",
-        "trigger_id": "trigger_generic"
+        "workflow_slug": "my-workflow",
+        "trigger_node_id": "node_chat_trigger"
       }
     },
     "yao_telegram": {
@@ -64,8 +64,8 @@
         "poll_timeout": 30
       },
       "route": {
-        "workflow_id": "wf_abc123",
-        "trigger_id": "trigger_telegram_yao"
+        "workflow_slug": "my-workflow",
+        "trigger_node_id": "node_telegram_trigger"
       }
     },
     "dev_opencode": {

--- a/crates/gw-cli/Cargo.toml
+++ b/crates/gw-cli/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "gw-cli"
+version = "0.1.0"
+edition = "2024"
+description = "CLI tool for msg-gateway — chat, admin, and health commands"
+
+[[bin]]
+name = "gw-cli"
+path = "src/main.rs"
+
+[dependencies]
+# CLI
+clap = { version = "4", features = ["derive", "env"] }
+
+# Async runtime
+tokio = { version = "1", features = ["full"] }
+tokio-util = "0.7"
+
+# HTTP client (rustls to avoid OpenSSL dependency)
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+
+# WebSocket client
+tokio-tungstenite = { version = "0.26", features = ["rustls-tls-webpki-roots"] }
+futures-util = "0.3"
+
+# Serialization
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+# Utilities
+chrono = { version = "0.4", features = ["serde"] }
+anyhow = "1"
+url = "2"

--- a/crates/gw-cli/src/client.rs
+++ b/crates/gw-cli/src/client.rs
@@ -1,0 +1,312 @@
+//! HTTP + WebSocket client for the msg-gateway API.
+
+use anyhow::{Context, Result, bail};
+use futures_util::StreamExt;
+use reqwest::header;
+use serde::{Deserialize, Serialize};
+use tokio_tungstenite::tungstenite;
+
+// ---------------------------------------------------------------------------
+// Response / request types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize)]
+pub struct ChatRequest {
+    pub chat_id: String,
+    pub text: String,
+    pub from: ChatUser,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ChatUser {
+    pub id: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ChatResponse {
+    pub message_id: String,
+    pub timestamp: String,
+}
+
+/// A message received on the WebSocket (outbound from gateway).
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct WsMessage {
+    pub text: String,
+    pub timestamp: String,
+    pub message_id: String,
+    #[serde(default)]
+    pub file_urls: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HealthResponse {
+    pub status: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct CredentialInfo {
+    pub id: String,
+    pub adapter: String,
+    pub active: bool,
+    #[serde(default)]
+    pub backend: Option<String>,
+    #[serde(default)]
+    pub route: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CredentialListResponse {
+    pub credentials: Vec<CredentialInfo>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CreateCredentialRequest {
+    pub id: String,
+    pub adapter: String,
+    pub token: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub backend: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub route: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config: Option<serde_json::Value>,
+    pub active: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Gateway HTTP Client
+// ---------------------------------------------------------------------------
+
+pub struct GatewayClient {
+    http: reqwest::Client,
+    pub base_url: String,
+}
+
+impl GatewayClient {
+    pub fn new(base_url: &str) -> Self {
+        Self {
+            http: reqwest::Client::new(),
+            base_url: base_url.trim_end_matches('/').to_string(),
+        }
+    }
+
+    // -- Chat / Send (uses credential token) --------------------------------
+
+    pub async fn send_chat_message(
+        &self,
+        credential_id: &str,
+        chat_id: &str,
+        text: &str,
+        user_id: &str,
+        token: &str,
+    ) -> Result<ChatResponse> {
+        let url = format!("{}/api/v1/chat/{}", self.base_url, credential_id);
+        let body = ChatRequest {
+            chat_id: chat_id.to_string(),
+            text: text.to_string(),
+            from: ChatUser {
+                id: user_id.to_string(),
+            },
+        };
+
+        let resp = self
+            .http
+            .post(&url)
+            .header(header::AUTHORIZATION, format!("Bearer {}", token))
+            .json(&body)
+            .send()
+            .await
+            .context("Failed to connect to gateway")?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            bail!("Gateway returned {} — {}", status, body);
+        }
+
+        resp.json::<ChatResponse>()
+            .await
+            .context("Failed to parse chat response")
+    }
+
+    // -- WebSocket (uses credential token) ----------------------------------
+
+    /// Connect to the WebSocket endpoint and return the stream.
+    /// The returned stream yields `WsMessage` items.
+    pub async fn connect_ws(
+        &self,
+        credential_id: &str,
+        chat_id: &str,
+        token: &str,
+    ) -> Result<std::pin::Pin<Box<dyn futures_util::Stream<Item = Result<WsMessage>> + Send>>> {
+        let ws_url = self
+            .base_url
+            .replacen("http://", "ws://", 1)
+            .replacen("https://", "wss://", 1);
+        let url = format!("{}/ws/chat/{}/{}", ws_url, credential_id, chat_id);
+
+        let request = tungstenite::http::Request::builder()
+            .uri(&url)
+            .header("Authorization", format!("Bearer {}", token))
+            .header("Host", extract_host(&self.base_url))
+            .header("Connection", "Upgrade")
+            .header("Upgrade", "websocket")
+            .header("Sec-WebSocket-Version", "13")
+            .header(
+                "Sec-WebSocket-Key",
+                tungstenite::handshake::client::generate_key(),
+            )
+            .body(())
+            .context("Failed to build WebSocket request")?;
+
+        let (ws_stream, _resp) = tokio_tungstenite::connect_async(request)
+            .await
+            .context("Failed to connect WebSocket")?;
+
+        let mapped = ws_stream.filter_map(|msg| async {
+            match msg {
+                Ok(tungstenite::Message::Text(text)) => {
+                    match serde_json::from_str::<WsMessage>(&text) {
+                        Ok(ws_msg) => Some(Ok(ws_msg)),
+                        Err(e) => Some(Err(anyhow::anyhow!("Failed to parse WS message: {}", e))),
+                    }
+                }
+                Ok(tungstenite::Message::Close(_)) => None,
+                Ok(_) => None, // Ping/Pong handled by tungstenite
+                Err(e) => Some(Err(anyhow::anyhow!("WebSocket error: {}", e))),
+            }
+        });
+
+        Ok(Box::pin(mapped))
+    }
+
+    // -- Admin (uses admin token) -------------------------------------------
+
+    pub async fn health(&self) -> Result<HealthResponse> {
+        let url = format!("{}/health", self.base_url);
+        let resp = self
+            .http
+            .get(&url)
+            .send()
+            .await
+            .context("Failed to connect to gateway")?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            bail!("Health check failed: {}", status);
+        }
+
+        resp.json::<HealthResponse>()
+            .await
+            .context("Failed to parse health response")
+    }
+
+    pub async fn list_credentials(&self, admin_token: &str) -> Result<Vec<CredentialInfo>> {
+        let url = format!("{}/admin/credentials", self.base_url);
+        let resp = self
+            .http
+            .get(&url)
+            .header(header::AUTHORIZATION, format!("Bearer {}", admin_token))
+            .send()
+            .await
+            .context("Failed to connect to gateway")?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            bail!("Failed to list credentials: {} — {}", status, body);
+        }
+
+        let list = resp
+            .json::<CredentialListResponse>()
+            .await
+            .context("Failed to parse credentials response")?;
+
+        Ok(list.credentials)
+    }
+
+    pub async fn create_credential(
+        &self,
+        admin_token: &str,
+        req: &CreateCredentialRequest,
+    ) -> Result<serde_json::Value> {
+        let url = format!("{}/admin/credentials", self.base_url);
+        let resp = self
+            .http
+            .post(&url)
+            .header(header::AUTHORIZATION, format!("Bearer {}", admin_token))
+            .json(req)
+            .send()
+            .await
+            .context("Failed to connect to gateway")?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            bail!("Failed to create credential: {} — {}", status, body);
+        }
+
+        resp.json::<serde_json::Value>()
+            .await
+            .context("Failed to parse create response")
+    }
+
+    pub async fn activate_credential(
+        &self,
+        admin_token: &str,
+        id: &str,
+    ) -> Result<serde_json::Value> {
+        let url = format!("{}/admin/credentials/{}/activate", self.base_url, id);
+        let resp = self
+            .http
+            .patch(&url)
+            .header(header::AUTHORIZATION, format!("Bearer {}", admin_token))
+            .send()
+            .await
+            .context("Failed to connect to gateway")?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            bail!("Failed to activate credential: {} — {}", status, body);
+        }
+
+        resp.json::<serde_json::Value>()
+            .await
+            .context("Failed to parse response")
+    }
+
+    pub async fn deactivate_credential(
+        &self,
+        admin_token: &str,
+        id: &str,
+    ) -> Result<serde_json::Value> {
+        let url = format!("{}/admin/credentials/{}/deactivate", self.base_url, id);
+        let resp = self
+            .http
+            .patch(&url)
+            .header(header::AUTHORIZATION, format!("Bearer {}", admin_token))
+            .send()
+            .await
+            .context("Failed to connect to gateway")?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            bail!("Failed to deactivate credential: {} — {}", status, body);
+        }
+
+        resp.json::<serde_json::Value>()
+            .await
+            .context("Failed to parse response")
+    }
+}
+
+fn extract_host(url: &str) -> String {
+    url.trim_start_matches("http://")
+        .trim_start_matches("https://")
+        .split('/')
+        .next()
+        .unwrap_or("localhost")
+        .to_string()
+}

--- a/crates/gw-cli/src/commands/chat.rs
+++ b/crates/gw-cli/src/commands/chat.rs
@@ -1,0 +1,126 @@
+//! `gw-cli chat` — interactive REPL combining send + listen.
+//!
+//! Connects WebSocket first, then reads user input line by line,
+//! sends each line as a chat message, and displays responses as they arrive.
+
+use anyhow::Result;
+use futures_util::StreamExt;
+use std::io::Write;
+use tokio::io::AsyncBufReadExt;
+use tokio_util::sync::CancellationToken;
+
+use crate::client::GatewayClient;
+use crate::output;
+
+use super::Context;
+
+const WS_DRAIN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+
+pub async fn run(ctx: &Context, credential_id: &str, chat_id: &str, user_id: &str) -> Result<()> {
+    let token = ctx.require_token()?.to_string();
+    let gateway_url = ctx.gateway_url.clone();
+    let json_output = ctx.json_output;
+    let credential_id = credential_id.to_string();
+    let chat_id = chat_id.to_string();
+    let user_id = user_id.to_string();
+
+    let client = GatewayClient::new(&gateway_url);
+
+    output::status(&format!("Connecting to gateway at {}...", client.base_url));
+
+    let mut ws_stream = client.connect_ws(&credential_id, &chat_id, &token).await?;
+
+    output::status(&format!(
+        "Connected. Chat session: credential={}, chat_id={}",
+        credential_id, chat_id
+    ));
+    output::status("Type your message and press Enter. Ctrl+C to exit.\n");
+
+    let cancel = CancellationToken::new();
+    let cancel_ws = cancel.clone();
+
+    let ws_task = tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                _ = cancel_ws.cancelled() => break,
+                msg = ws_stream.next() => {
+                    match msg {
+                        Some(Ok(msg)) => {
+                            if json_output {
+                                output::print_jsonl(&msg);
+                            } else {
+                                println!("\n< {}", msg.text);
+                                if !msg.file_urls.is_empty() {
+                                    for url in &msg.file_urls {
+                                        println!("  [file] {}", url);
+                                    }
+                                }
+                                print!("> ");
+                                let _ = std::io::stdout().flush();
+                            }
+                        }
+                        Some(Err(e)) => {
+                            output::error(&format!("WebSocket error: {}", e));
+                            break;
+                        }
+                        None => break,
+                    }
+                }
+            }
+        }
+    });
+
+    let stdin = tokio::io::BufReader::new(tokio::io::stdin());
+    let mut lines = stdin.lines();
+
+    let send_client = GatewayClient::new(&gateway_url);
+
+    loop {
+        if !json_output {
+            print!("> ");
+            let _ = std::io::stdout().flush();
+        }
+
+        let line = match lines.next_line().await? {
+            Some(line) => line,
+            None => break,
+        };
+
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        match send_client
+            .send_chat_message(&credential_id, &chat_id, trimmed, &user_id, &token)
+            .await
+        {
+            Ok(resp) => {
+                if json_output {
+                    output::print_jsonl(&resp);
+                }
+            }
+            Err(e) => {
+                output::error(&format!("Send failed: {}", e));
+            }
+        }
+    }
+
+    // Signal WS task to stop and wait for it to drain remaining messages
+    cancel.cancel();
+    match tokio::time::timeout(WS_DRAIN_TIMEOUT, ws_task).await {
+        Ok(result) => {
+            if let Err(e) = result {
+                if !e.is_cancelled() {
+                    output::error(&format!("WebSocket task error: {}", e));
+                }
+            }
+        }
+        Err(_) => {
+            output::status("WebSocket drain timed out, closing.");
+        }
+    }
+
+    output::status("\nChat session ended.");
+    Ok(())
+}

--- a/crates/gw-cli/src/commands/credentials.rs
+++ b/crates/gw-cli/src/commands/credentials.rs
@@ -1,0 +1,65 @@
+//! `gw credentials` — admin CRUD operations for gateway credentials.
+
+use anyhow::Result;
+
+use crate::client::{CreateCredentialRequest, GatewayClient};
+use crate::output;
+
+use super::Context;
+
+pub async fn run(ctx: &Context, cmd: crate::CredentialCommands) -> Result<()> {
+    let admin_token = ctx.require_admin_token()?;
+    let client = GatewayClient::new(&ctx.gateway_url);
+
+    match cmd {
+        crate::CredentialCommands::List => {
+            let creds = client.list_credentials(admin_token).await?;
+            output::print_result(&creds, ctx.json_output);
+        }
+
+        crate::CredentialCommands::Create {
+            id,
+            adapter,
+            token,
+            backend,
+            route,
+            config,
+            active,
+        } => {
+            let route_value = route
+                .map(|r| serde_json::from_str(&r))
+                .transpose()
+                .map_err(|e| anyhow::anyhow!("Invalid --route JSON: {}", e))?;
+
+            let config_value = config
+                .map(|c| serde_json::from_str(&c))
+                .transpose()
+                .map_err(|e| anyhow::anyhow!("Invalid --config JSON: {}", e))?;
+
+            let req = CreateCredentialRequest {
+                id,
+                adapter,
+                token,
+                backend,
+                route: route_value,
+                config: config_value,
+                active,
+            };
+
+            let result = client.create_credential(admin_token, &req).await?;
+            output::print_result(&result, ctx.json_output);
+        }
+
+        crate::CredentialCommands::Activate { id } => {
+            let result = client.activate_credential(admin_token, &id).await?;
+            output::print_result(&result, ctx.json_output);
+        }
+
+        crate::CredentialCommands::Deactivate { id } => {
+            let result = client.deactivate_credential(admin_token, &id).await?;
+            output::print_result(&result, ctx.json_output);
+        }
+    }
+
+    Ok(())
+}

--- a/crates/gw-cli/src/commands/health.rs
+++ b/crates/gw-cli/src/commands/health.rs
@@ -1,0 +1,19 @@
+//! `gw-cli health` — check gateway health status.
+
+use anyhow::Result;
+
+use crate::client::GatewayClient;
+use crate::output;
+
+use super::Context;
+
+/// Returns `Ok(true)` when healthy, `Ok(false)` when unhealthy.
+pub async fn run(ctx: &Context) -> Result<bool> {
+    let client = GatewayClient::new(&ctx.gateway_url);
+
+    let health = client.health().await?;
+
+    output::print_result(&health, ctx.json_output);
+
+    Ok(health.status == "ok")
+}

--- a/crates/gw-cli/src/commands/listen.rs
+++ b/crates/gw-cli/src/commands/listen.rs
@@ -1,0 +1,40 @@
+//! `gw listen` — stream outbound messages from WebSocket as JSONL.
+//!
+//! Connects to the gateway WebSocket and prints each message as a JSON line
+//! to stdout. Designed for piping to jq, agent consumption, or scripting.
+
+use anyhow::Result;
+use futures_util::StreamExt;
+
+use crate::client::GatewayClient;
+use crate::output;
+
+use super::Context;
+
+pub async fn run(ctx: &Context, credential_id: &str, chat_id: &str) -> Result<()> {
+    let token = ctx.require_token()?;
+    let client = GatewayClient::new(&ctx.gateway_url);
+
+    output::status(&format!(
+        "Connecting to {}/ws/chat/{}/{}",
+        client.base_url, credential_id, chat_id
+    ));
+
+    let mut stream = client.connect_ws(credential_id, chat_id, token).await?;
+
+    output::status("Connected. Listening for messages...");
+
+    while let Some(result) = stream.next().await {
+        match result {
+            Ok(msg) => {
+                output::print_jsonl(&msg);
+            }
+            Err(e) => {
+                return Err(e.into());
+            }
+        }
+    }
+
+    output::status("WebSocket disconnected.");
+    Ok(())
+}

--- a/crates/gw-cli/src/commands/mod.rs
+++ b/crates/gw-cli/src/commands/mod.rs
@@ -1,0 +1,29 @@
+pub mod chat;
+pub mod credentials;
+pub mod health;
+pub mod listen;
+pub mod send;
+
+/// Shared context passed to all commands.
+pub struct Context {
+    pub gateway_url: String,
+    pub token: Option<String>,
+    pub admin_token: Option<String>,
+    pub json_output: bool,
+}
+
+impl Context {
+    /// Get the credential token or bail with a helpful error.
+    pub fn require_token(&self) -> anyhow::Result<&str> {
+        self.token.as_deref().ok_or_else(|| {
+            anyhow::anyhow!("Missing credential token. Set --token or GATEWAY_TOKEN")
+        })
+    }
+
+    /// Get the admin token or bail with a helpful error.
+    pub fn require_admin_token(&self) -> anyhow::Result<&str> {
+        self.admin_token.as_deref().ok_or_else(|| {
+            anyhow::anyhow!("Missing admin token. Set --admin-token or GATEWAY_ADMIN_TOKEN")
+        })
+    }
+}

--- a/crates/gw-cli/src/commands/send.rs
+++ b/crates/gw-cli/src/commands/send.rs
@@ -1,0 +1,50 @@
+//! `gw send` — one-shot message send.
+//!
+//! Reads text from --text flag or stdin, POSTs to the generic chat endpoint,
+//! prints the result as JSON.
+
+use anyhow::Result;
+use std::io::Read;
+
+use crate::client::GatewayClient;
+use crate::output;
+
+use super::Context;
+
+pub async fn run(
+    ctx: &Context,
+    credential_id: &str,
+    chat_id: &str,
+    text: Option<&str>,
+    user_id: &str,
+) -> Result<()> {
+    let token = ctx.require_token()?;
+    let client = GatewayClient::new(&ctx.gateway_url);
+
+    // Get text from --text flag or stdin
+    let message_text = match text {
+        Some(t) => t.to_string(),
+        None => {
+            if std::io::IsTerminal::is_terminal(&std::io::stdin()) {
+                output::status("Reading message from stdin (Ctrl+D to send):");
+            }
+            let mut buf = String::new();
+            std::io::stdin()
+                .read_to_string(&mut buf)
+                .map_err(|e| anyhow::anyhow!("Failed to read stdin: {}", e))?;
+            let trimmed = buf.trim_end().to_string();
+            if trimmed.is_empty() {
+                anyhow::bail!("No message text provided. Use --text or pipe to stdin.");
+            }
+            trimmed
+        }
+    };
+
+    let resp = client
+        .send_chat_message(credential_id, chat_id, &message_text, user_id, token)
+        .await?;
+
+    output::print_result(&resp, ctx.json_output);
+
+    Ok(())
+}

--- a/crates/gw-cli/src/main.rs
+++ b/crates/gw-cli/src/main.rs
@@ -1,0 +1,182 @@
+use clap::{Parser, Subcommand};
+
+mod client;
+mod commands;
+mod output;
+
+/// gw-cli — CLI tool for msg-gateway
+///
+/// Send and receive messages, manage credentials, and check health.
+/// Talks to the gateway's generic adapter interface — works with any backend.
+#[derive(Parser)]
+#[command(name = "gw-cli", version, about)]
+struct Cli {
+    /// Gateway URL
+    #[arg(
+        long,
+        env = "GATEWAY_URL",
+        default_value = "http://localhost:8080",
+        global = true
+    )]
+    gateway_url: String,
+
+    /// Credential token (for chat/send/listen commands)
+    #[arg(long, env = "GATEWAY_TOKEN", global = true)]
+    token: Option<String>,
+
+    /// Admin token (for credentials/health commands)
+    #[arg(long, env = "GATEWAY_ADMIN_TOKEN", global = true)]
+    admin_token: Option<String>,
+
+    /// Force JSON output (auto-enabled when stdout is not a TTY)
+    #[arg(long, global = true)]
+    json: bool,
+
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Interactive chat REPL — send messages and see responses in real time
+    Chat {
+        /// Credential ID to chat through
+        credential_id: String,
+
+        /// Chat/conversation ID
+        #[arg(long)]
+        chat_id: String,
+
+        /// Your user ID (sent as from.id)
+        #[arg(long, default_value = "cli-user")]
+        user_id: String,
+    },
+
+    /// Send a single message (fire-and-forget)
+    Send {
+        /// Credential ID to send through
+        credential_id: String,
+
+        /// Chat/conversation ID
+        #[arg(long)]
+        chat_id: String,
+
+        /// Message text (reads from stdin if omitted)
+        #[arg(long)]
+        text: Option<String>,
+
+        /// Your user ID (sent as from.id)
+        #[arg(long, default_value = "cli-user")]
+        user_id: String,
+    },
+
+    /// Listen for outbound messages on a WebSocket (streams JSONL to stdout)
+    Listen {
+        /// Credential ID to listen on
+        credential_id: String,
+
+        /// Chat/conversation ID
+        #[arg(long)]
+        chat_id: String,
+    },
+
+    /// Credential management
+    #[command(subcommand)]
+    Credentials(CredentialCommands),
+
+    /// Check gateway health
+    Health,
+}
+
+#[derive(Subcommand)]
+enum CredentialCommands {
+    /// List all credentials
+    List,
+
+    /// Create a new credential
+    Create {
+        /// Credential ID
+        id: String,
+
+        /// Adapter type (e.g. "generic", "telegram")
+        #[arg(long)]
+        adapter: String,
+
+        /// Credential token
+        #[arg(long)]
+        token: String,
+
+        /// Backend to route to (e.g. "pipelit", "opencode")
+        #[arg(long)]
+        backend: Option<String>,
+
+        /// Route config as JSON string
+        #[arg(long)]
+        route: Option<String>,
+
+        /// Adapter-specific config as JSON string
+        #[arg(long)]
+        config: Option<String>,
+
+        /// Activate immediately
+        #[arg(long)]
+        active: bool,
+    },
+
+    /// Activate a credential
+    Activate {
+        /// Credential ID
+        id: String,
+    },
+
+    /// Deactivate a credential
+    Deactivate {
+        /// Credential ID
+        id: String,
+    },
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+
+    let is_tty = std::io::IsTerminal::is_terminal(&std::io::stdout());
+    let json_output = cli.json || !is_tty;
+
+    let ctx = commands::Context {
+        gateway_url: cli.gateway_url,
+        token: cli.token,
+        admin_token: cli.admin_token,
+        json_output,
+    };
+
+    match cli.command {
+        Commands::Chat {
+            credential_id,
+            chat_id,
+            user_id,
+        } => commands::chat::run(&ctx, &credential_id, &chat_id, &user_id).await,
+
+        Commands::Send {
+            credential_id,
+            chat_id,
+            text,
+            user_id,
+        } => commands::send::run(&ctx, &credential_id, &chat_id, text.as_deref(), &user_id).await,
+
+        Commands::Listen {
+            credential_id,
+            chat_id,
+        } => commands::listen::run(&ctx, &credential_id, &chat_id).await,
+
+        Commands::Credentials(cmd) => commands::credentials::run(&ctx, cmd).await,
+
+        Commands::Health => {
+            let healthy = commands::health::run(&ctx).await?;
+            if !healthy {
+                std::process::exit(1);
+            }
+            Ok(())
+        }
+    }
+}

--- a/crates/gw-cli/src/output.rs
+++ b/crates/gw-cli/src/output.rs
@@ -1,0 +1,41 @@
+//! TTY-aware output formatting.
+//!
+//! When stdout is a TTY (interactive), output is human-friendly.
+//! When piped or `--json` is set, output is JSON (JSONL for streams).
+
+use serde::Serialize;
+
+/// Print a single value — JSON when json_output, human-friendly otherwise.
+pub fn print_result<T: Serialize + std::fmt::Debug>(value: &T, json_output: bool) {
+    if json_output {
+        // Compact JSON to stdout
+        println!(
+            "{}",
+            serde_json::to_string(value).expect("Failed to serialize output")
+        );
+    } else {
+        // Pretty debug for now — can be enhanced with table formatting later
+        println!(
+            "{}",
+            serde_json::to_string_pretty(value).expect("Failed to serialize output")
+        );
+    }
+}
+
+/// Print a single JSONL line (for streaming output like `gw listen`).
+pub fn print_jsonl<T: Serialize>(value: &T) {
+    println!(
+        "{}",
+        serde_json::to_string(value).expect("Failed to serialize output")
+    );
+}
+
+/// Print a status/info message to stderr (never interferes with stdout data).
+pub fn status(msg: &str) {
+    eprintln!("{}", msg);
+}
+
+/// Print an error message to stderr.
+pub fn error(msg: &str) {
+    eprintln!("error: {}", msg);
+}

--- a/docs/dev-plans/gw-cli.md
+++ b/docs/dev-plans/gw-cli.md
@@ -1,0 +1,265 @@
+# `gw-cli` CLI Tool — Development Plan
+
+**Status:** Ready
+**Blocked by:** None (gateway API endpoints all exist)
+**Priority:** P0 — needed for Pipelit integration testing and agent tooling
+
+---
+
+## Summary
+
+A standalone Rust CLI binary (`gw-cli`) for interacting with the msg-gateway. The gateway server binary is `gw-server`. Supports interactive chat, one-shot message sending, WebSocket listening, credential management, and health checks. Designed as a unix-philosophy tool: pipe-friendly, JSON-native, and usable by both humans and AI agents.
+
+## Requirements
+
+1. **Unix-philosophy compatible** — stdin/stdout/stderr, proper exit codes, pipe-friendly
+2. **Single tool** — standalone binary, no runtime dependencies
+3. **TUI embeddable** — callable as subprocess from TUI applications
+4. **Agent-usable** — structured JSON output, non-interactive modes for programmatic access
+
+## Command Structure
+
+### Chat Commands (Generic Adapter)
+
+These commands work regardless of what backend the credential is routed to — they talk to the gateway's generic adapter interface.
+
+```bash
+# Interactive REPL — connect WS + send loop
+gw-cli chat <credential_id> --chat-id <id>
+
+# One-shot send (pipe-friendly)
+gw-cli send <credential_id> --chat-id <id> --text "hello"
+echo "hello" | gw-cli send <credential_id> --chat-id <id>
+gw-cli send <credential_id> --chat-id <id> < message.txt
+
+# Listen only — stream JSONL to stdout
+gw-cli listen <credential_id> --chat-id <id>
+```
+
+### Admin Commands
+
+```bash
+# Credential management
+gw-cli credentials list
+gw-cli credentials create <id> --adapter <type> --token <tok> \
+  --backend <name> --route '{"workflow_slug":"...","trigger_node_id":"..."}'
+gw-cli credentials activate <id>
+gw-cli credentials deactivate <id>
+
+# Health check
+gw-cli health
+```
+
+### I/O Behavior
+
+| Mode | stdin | stdout | stderr | Exit code |
+|------|-------|--------|--------|-----------|
+| `gw-cli chat` | interactive input | formatted responses | connection status | 0 |
+| `gw-cli send` | reads text if no `--text` | JSON result | errors | 0/1 |
+| `gw-cli listen` | — | JSONL stream (one msg per line) | connection status | 0/1 |
+| `gw-cli credentials list` | — | JSON array | errors | 0/1 |
+| `gw-cli health` | — | JSON status | errors | 0/1 |
+
+### Global Flags
+
+```
+--gateway-url <url>      (env: GATEWAY_URL, default: http://localhost:8080)
+--token <token>          (env: GATEWAY_TOKEN — credential token for chat/send/listen)
+--admin-token <token>    (env: GATEWAY_ADMIN_TOKEN — for credentials/health commands)
+--send-token <token>     (env: GATEWAY_SEND_TOKEN — not typically needed by CLI users)
+--json                   (force JSON output; auto-enabled when stdout is not a TTY)
+--no-color               (disable colored output)
+```
+
+## Architecture
+
+### How It Works
+
+The CLI is purely a gateway client. It doesn't know about backends (Pipelit, OpenCode, etc.).
+
+```
+gw-cli send → POST /api/v1/chat/{credential_id}       → Gateway routes to backend
+gw-cli listen → WS /ws/chat/{credential_id}/{chat_id}  → Gateway pushes responses
+gw-cli chat  → send + listen combined in interactive REPL
+gw-cli credentials → /admin/credentials/*              → Gateway admin API
+gw-cli health → GET /health                            → Gateway health endpoint
+```
+
+### Auth Flow
+
+- **chat/send/listen**: Uses the credential's token (Bearer auth against the generic adapter endpoint)
+- **credentials/health**: Uses the admin token (Bearer auth against the admin API)
+
+### Auto-detection
+
+- When stdout is a TTY → human-readable output with colors
+- When stdout is piped → JSON output (JSONL for streams)
+- `--json` flag overrides to always JSON
+- `--no-color` flag disables colors even on TTY
+
+## Project Structure
+
+```
+msg-gateway/
+├── Cargo.toml              # workspace root (add gw-cli member)
+├── crates/
+│   └── gw-cli/
+│       ├── Cargo.toml      # binary crate
+│       └── src/
+│           ├── main.rs     # clap entry point
+│           ├── commands/
+│           │   ├── mod.rs
+│           │   ├── chat.rs         # interactive REPL
+│           │   ├── send.rs         # one-shot send
+│           │   ├── listen.rs       # WS stream listener
+│           │   ├── credentials.rs  # admin CRUD
+│           │   └── health.rs       # health check
+│           ├── client.rs           # HTTP + WS gateway client
+│           └── output.rs           # JSON / human-readable formatter
+└── src/                    # existing gateway code (unchanged)
+```
+
+## Dependencies
+
+| Crate | Purpose |
+|-------|---------|
+| `clap` (derive) | CLI argument parsing |
+| `reqwest` + `rustls-tls` | HTTP client (matches gateway, no OpenSSL) |
+| `tokio-tungstenite` + `rustls` | WebSocket client |
+| `tokio` (full) | Async runtime |
+| `serde` / `serde_json` | JSON serialization |
+| `chrono` | Timestamp formatting |
+| `colored` or `owo-colors` | Terminal colors (optional) |
+| `atty` or `std::io::IsTerminal` | TTY detection |
+
+## Implementation Phases
+
+### Phase 1 — Project Setup & Client Foundation
+
+- [ ] Create workspace layout (`Cargo.toml` workspace, `crates/gw-cli/`)
+- [ ] Set up `clap` with subcommands skeleton
+- [ ] Implement `client.rs` — HTTP client for gateway API
+  - `send_chat_message(credential_id, chat_id, text, token)` → POST /api/v1/chat/{cred}
+  - `list_credentials(admin_token)` → GET /admin/credentials
+  - `create_credential(...)` → POST /admin/credentials
+  - `activate_credential(id)` → PATCH /admin/credentials/{id}/activate
+  - `deactivate_credential(id)` → PATCH /admin/credentials/{id}/deactivate
+  - `health_check()` → GET /health
+- [ ] Implement `output.rs` — TTY-aware JSON/human formatter
+- [ ] Global flag handling (env vars, defaults)
+
+### Phase 2 — Core Commands
+
+- [ ] `gw-cli send` — one-shot message send
+  - Read from `--text` flag or stdin
+  - POST to generic chat endpoint
+  - Print JSON result to stdout
+  - Proper exit codes
+- [ ] `gw-cli listen` — WebSocket stream
+  - Connect to WS endpoint with auth
+  - Stream JSONL to stdout (one `WsOutboundMessage` per line)
+  - Auto-reconnect on disconnect (with backoff)
+  - Clean shutdown on SIGINT/SIGTERM
+- [ ] `gw-cli health` — health check
+  - GET /health
+  - Print JSON status
+  - Exit 0 if healthy, 1 if unhealthy
+
+### Phase 3 — Interactive Chat
+
+- [ ] `gw-cli chat` — interactive REPL
+  - Connect WebSocket first (listen for responses)
+  - Read user input line by line
+  - POST each line as chat message
+  - Display responses as they arrive on WS
+  - Handle multi-line input (paste detection or explicit mode)
+  - Ctrl+C for clean exit
+  - History support (optional, via `rustyline`)
+
+### Phase 4 — Admin Commands
+
+- [ ] `gw-cli credentials list` — list all credentials (JSON table)
+- [ ] `gw-cli credentials create` — create credential with all fields
+  - `--route` accepts JSON string
+  - `--config` accepts JSON string (optional)
+  - `--backend` names which backend to route to
+- [ ] `gw-cli credentials activate <id>` — activate credential
+- [ ] `gw-cli credentials deactivate <id>` — deactivate credential
+
+### Phase 5 — Polish
+
+- [ ] CI integration (build gw-cli in existing workflow)
+- [ ] Man page / `--help` examples
+- [ ] Shell completion generation (clap feature)
+- [ ] Config file support (optional: `~/.config/gw/config.toml`)
+
+## Usage Examples
+
+### Testing Pipelit Integration
+
+```bash
+# Set up environment
+export GATEWAY_URL=http://localhost:8080
+export GATEWAY_TOKEN=my-credential-token
+export GATEWAY_ADMIN_TOKEN=my-admin-token
+
+# Check gateway is running
+gw-cli health
+
+# Interactive chat with a Pipelit workflow
+gw-cli chat my_chat --chat-id test-session-1
+
+# One-shot send (useful in scripts)
+gw-cli send my_chat --chat-id test-1 --text "Run the analysis workflow"
+
+# Listen for responses (pipe to jq for pretty printing)
+gw-cli listen my_chat --chat-id test-1 | jq .
+
+# Pipe input from file
+cat prompt.txt | gw-cli send my_chat --chat-id test-1
+```
+
+### Agent Usage (AI agent calling gw as a tool)
+
+```bash
+# Send and capture message ID
+RESULT=$(gw-cli send my_chat --chat-id session-1 --text "analyze this data" --json)
+echo $RESULT  # {"message_id":"generic_xxx","timestamp":"..."}
+
+# Stream responses as JSONL (agent reads line by line)
+gw-cli listen my_chat --chat-id session-1 --json
+# {"text":"Processing...","timestamp":"...","message_id":"...","file_urls":[]}
+# {"text":"Analysis complete.","timestamp":"...","message_id":"...","file_urls":["http://..."]}
+```
+
+### Admin Scripting
+
+```bash
+# Create a credential for a new workflow
+gw-cli credentials create prod_workflow \
+  --adapter generic \
+  --backend pipelit \
+  --token "$(openssl rand -hex 32)" \
+  --route '{"workflow_slug":"production-pipeline","trigger_node_id":"node_entry"}'
+
+# Activate it
+gw-cli credentials activate prod_workflow
+
+# List all credentials
+gw-cli credentials list | jq '.[] | select(.active == true)'
+```
+
+## Non-Goals
+
+- **No TUI framework** (no ratatui/crossterm) — this is a CLI tool, not a TUI app. TUIs call it as subprocess.
+- **No built-in retry/queue** — fire-and-forget. The gateway handles reliability.
+- **No file upload** — v1 is text-only. File support can be added later via `--file` flag.
+- **No multi-credential chat** — one credential per session. Use multiple terminal tabs.
+
+## Success Criteria
+
+1. `gw-cli send` + `gw-cli listen` can round-trip a message through gateway → Pipelit → gateway
+2. `gw-cli chat` provides interactive experience comparable to a chat client
+3. `echo "hello" | gw-cli send ... | jq .` works end-to-end (pipe-friendly)
+4. `gw-cli listen ... | while read line; do ... done` works for agent consumption
+5. All commands exit 0 on success, 1 on failure, with errors on stderr

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -17,50 +17,32 @@ msg-gateway is the unified messaging layer for Pipelit and other LLM-based appli
 - Admin API for credential management
 - ~80% test coverage
 
-## v0.2.0 - Adapters & E2E Testing (Target: Apr 2026)
+## v0.2.0 - Foundation & E2E Testing (Target: Apr 2026)
 
 ### Goals
 1. Establish E2E testing framework with BDD/Gherkin
-2. Migrate all adapters to Node.js (no virtualenv dependency)
-3. Add Email, Slack, Discord adapters
-4. Complete protocol documentation
+2. Migrate Telegram adapter to Node.js (no virtualenv dependency)
+3. Message format redesign with file support
+4. Named backends with per-credential routing
+5. CEL-based message guardrails with hot-reload
+6. OpenCode backend adapter (built-in + external)
 
 ### Tasks
 
-| Order | Issue | Task | Priority | Estimate | Blocked By | Status |
-|-------|-------|------|----------|----------|------------|--------|
-| 1 | #15 | Message Format Redesign (core fields, files[], extra_data) | P0 | 2-3 days | — | ✅ Done |
-| 2 | #16 | File Upload API (POST /api/v1/files) | P0 | 1-2 days | #15 | ✅ Done |
-| 3 | #12 | E2E Test Framework (Cucumber-JS) | P0 | 3-4 days | #15 | ✅ Done |
-| 4 | #13 | Telegram Adapter → Node.js | P0 | 2-3 days | #15, #12 | ✅ Done |
-| 5 | #17 | Generic Adapter File Support | P1 | 1-2 days | #15, #16 | ✅ Done |
-| 6 | #11 | Email Adapter (Node.js) | P1 | 5-7 days | #15, #12 | Planned |
-| 7 | #10 | Slack Adapter (Node.js) | P1 | 3-5 days | #15, #12 | Planned |
-| 8 | #9 | Discord Adapter (Node.js) | P1 | 3-5 days | #15, #12 | Planned |
-| 9 | — | Protocol Documentation | P1 | 1 day | — | Planned |
-
-### Dependency Graph
-
-```
-#15 Message Format Redesign
- ├──▶ #16 File Upload API
- │     └──▶ #17 Generic Adapter File Support
- ├──▶ #12 E2E Test Framework
- │     ├──▶ #13 Telegram → Node.js
- │     ├──▶ #11 Email Adapter
- │     ├──▶ #10 Slack Adapter
- │     └──▶ #9  Discord Adapter
- └──▶ #8  Pipelit Integration (v0.3.0)
-```
-
-### Phases
-
-**Phase 1 — Foundation** (`phase:1-foundation`)
-- #15 → #16 → #17: Message format, file API, generic adapter files
-- #12: E2E test framework (can run in parallel with #16)
-
-**Phase 2 — Adapters** (`phase:2-adapters`)
-- #13, #11, #10, #9: All adapter work (depends on Phase 1)
+| Order | Issue | Task | Priority | Status |
+|-------|-------|------|----------|--------|
+| 1 | #15 | Message Format Redesign (core fields, files[], extra_data) | P0 | ✅ Done |
+| 2 | #16 | File Upload API (POST /api/v1/files) | P0 | ✅ Done |
+| 3 | #12 | E2E Test Framework (Cucumber-JS) | P0 | ✅ Done |
+| 4 | #13 | Telegram Adapter → Node.js | P0 | ✅ Done |
+| 5 | #17 | Generic Adapter File Support | P1 | ✅ Done |
+| 6 | #29 | Complete E2E Test Coverage (19 scenarios) | P1 | ✅ Done |
+| 7 | #32 | OpenCode Backend Adapter (built-in Rust) | P1 | ✅ Done |
+| 8 | #33 | External Backend Subprocess Protocol | P1 | ✅ Done |
+| 9 | #38 | Named Backends with Per-Credential Routing | P1 | ✅ Done |
+| 10 | #40 | CEL-Based Guardrails with Hot-Reload | P1 | ✅ Done |
+| 11 | #41 | OpenCode SSE Response Delivery + File Attachments | P1 | ✅ Done |
+| 12 | — | Protocol Documentation | P2 | Planned |
 
 ### Technical Decisions
 
@@ -76,44 +58,47 @@ msg-gateway is the unified messaging layer for Pipelit and other LLM-based appli
 - **HTTP Framework**: Fastify (lightweight, fast)
 - **Reason**: No virtualenv needed, fast startup, consistent tooling
 
-### Milestones
-
-```
-Week 1: Phase 1 — Foundation
-  ├── #15 Message Format Redesign (Rust structs + server logic)
-  ├── #16 File Upload API
-  ├── #12 E2E Test Framework (Cucumber-JS setup + CI)
-  └── #17 Generic Adapter File Support
-
-Week 2: Phase 2a — Telegram Migration
-  └── #13 Telegram Adapter → Node.js (first adapter on new format)
-
-Week 3-4: Phase 2b — New Adapters
-  ├── #11 Email Adapter (IMAP/SMTP)
-  ├── #10 Slack Adapter (Events API)
-  ├── #9  Discord Adapter (discord.js)
-  └── Protocol Documentation
-```
-
-## v0.3.0 - Pipelit Integration (Target: May 2026)
+## v0.3.0 - CLI Tool & Pipelit Integration (Target: May 2026)
 
 ### Goals
-1. Full integration with Pipelit unified inbound endpoint
-2. Multi-model routing support
-3. Production hardening
+1. `gw` CLI tool — unix-philosophy gateway client for chat, admin, and agent tooling
+2. Full integration with Pipelit unified inbound endpoint
+3. End-to-end protocol verification with real Pipelit instance
+4. Production hardening (rate limiting, observability)
 
 ### Tasks
 
-| Task | Priority | Related |
-|------|----------|---------|
-| Pipelit unified inbound endpoint | P0 | Pipelit #134 |
-| Protocol verification & testing | P0 | #8 |
-| Multi-model routing (Claude/GLM/MiniMax) | P1 | Pipelit #126 |
-| Rate limiting | P2 | - |
-| Metrics & observability | P2 | - |
+| Order | Task | Priority | Related | Status |
+|-------|------|----------|---------|--------|
+| 1 | `gw` CLI — project setup & client foundation | P0 | — | Planned |
+| 2 | `gw send` + `gw listen` + `gw health` commands | P0 | — | Planned |
+| 3 | `gw chat` interactive REPL | P0 | — | Planned |
+| 4 | `gw credentials` admin commands | P1 | — | Planned |
+| 5 | Pipelit unified inbound endpoint | P0 | Pipelit #134 | Planned |
+| 6 | Protocol verification & E2E testing | P0 | #8 | Planned |
+| 7 | Rate limiting | P2 | — | Planned |
+| 8 | Metrics & observability (Prometheus) | P2 | — | Planned |
+
+Dev plan: [`docs/dev-plans/gw-cli.md`](dev-plans/gw-cli.md)
+
+### OpenCode Enhancements (parallel track)
+
+| Issue | Task | Priority | Status |
+|-------|------|----------|--------|
+| #35 | Async message mode for OpenCode backend | P2 | Open |
+| #34 | Full OpenCode server mode integration | P2 | Open |
 
 ## Future Considerations (v0.4.0+)
 
+### Additional Adapters (deprioritized from v0.2.0)
+
+| Issue | Adapter | Estimate | Notes |
+|-------|---------|----------|-------|
+| #11 | Email (IMAP/SMTP) | 5-7 days | Dev plan in docs/dev-plans/email-adapter.md |
+| #10 | Slack (Events API) | 3-5 days | Dev plan in docs/dev-plans/slack-adapter.md |
+| #9 | Discord (discord.js) | 3-5 days | Dev plan in docs/dev-plans/discord-adapter.md |
+
+### Other
 - WhatsApp adapter
 - Microsoft Teams adapter
 - Matrix adapter

--- a/e2e/support/test-gateway.ts
+++ b/e2e/support/test-gateway.ts
@@ -23,8 +23,8 @@ function findFreePort(): Promise<number> {
 
 function findGatewayBinary(): string {
   const dir = path.resolve(__dirname, '../../');
-  const release = path.join(dir, 'target/release/msg-gateway');
-  const debug = path.join(dir, 'target/debug/msg-gateway');
+  const release = path.join(dir, 'target/release/gw-server');
+  const debug = path.join(dir, 'target/debug/gw-server');
   if (fs.existsSync(release)) return release;
   if (fs.existsSync(debug)) return debug;
   throw new Error(`Gateway binary not found at ${release} or ${debug}. Run 'cargo build' first.`);


### PR DESCRIPTION
## Summary

- Add `gw` CLI tool as a Cargo workspace member (`crates/gw-cli/`) — a standalone Rust binary for interacting with the gateway
- Update roadmap to reprioritize Pipelit integration and add CLI as v0.3.0 P0
- Fix `config.example.json` route fields to match actual Pipelit API contract (`workflow_slug`/`trigger_node_id`)

## CLI Commands

| Command | Description |
|---------|-------------|
| `gw chat <cred> --chat-id <id>` | Interactive REPL — WebSocket receive + HTTP send loop |
| `gw send <cred> --chat-id <id> --text "msg"` | One-shot send (also reads from stdin) |
| `gw listen <cred> --chat-id <id>` | Stream outbound messages as JSONL to stdout |
| `gw credentials list\|create\|activate\|deactivate` | Admin CRUD |
| `gw health` | Gateway health check |

## Design

- **Unix-philosophy**: pipe-friendly, JSON when piped, human-readable on TTY, proper exit codes
- **Backend-agnostic**: talks to the generic adapter API — works with Pipelit, OpenCode, or any backend
- **Agent-usable**: structured JSONL output for programmatic consumption
- **Zero runtime deps**: single static Rust binary

## Changes

- `crates/gw-cli/` — New CLI crate (10 source files)
- `Cargo.toml` — Convert to workspace, add `crates/gw-cli` member
- `docs/dev-plans/gw-cli.md` — Full development plan
- `docs/roadmap.md` — Reprioritized: adapters deprioritized, CLI + Pipelit integration moved to v0.3.0 P0
- `config.example.json` — Route fields fixed (`workflow_slug`/`trigger_node_id` per Pipelit contract)
- `.github/workflows/ci.yml` — Upload `gw` binary artifact
- `README.md` — CLI documentation section
- `CLAUDE.md` — Workspace structure and CLI file map

## Verification

- `cargo fmt --all -- --check` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅ (zero warnings)
- `cargo test --all-features` ✅ (43 tests pass)
- Manually tested `gw chat` against live OpenCode backend ✅