### PR TITLE
fix(ci): download plit CLI binary in E2E job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,12 +118,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download binaries
+      - name: Download plit-gw binary
         uses: actions/download-artifact@v4
         with:
-          pattern: plit-*-binary
+          name: plit-gw-binary
           path: target/release
-          merge-multiple: true
+
+      - name: Download plit binary
+        uses: actions/download-artifact@v4
+        with:
+          name: plit-binary
+          path: target/release
 
       - name: Make binaries executable
         run: chmod +x target/release/plit-gw target/release/plit


### PR DESCRIPTION
## Summary
- Download `plit` CLI binary artifact in the E2E test job (was only downloading `plit-gw`)
- Make both binaries executable

Prepares for future CLI integration tests. Follow-up from #50 rename.