### PR TITLE
feat(cli): add container detection and sandbox mode to plit init

### DIFF
--- a/crates/plit/src/commands/init/config.rs
+++ b/crates/plit/src/commands/init/config.rs
@@ -10,6 +10,7 @@ use std::path::PathBuf;
 use anyhow::{Context, Result};
 use serde::Serialize;
 
+use super::prereqs::Environment;
 use super::prompts::UserInputs;
 use super::tokens::SharedTokens;
 use crate::output;
@@ -84,14 +85,13 @@ pub fn venv_dir() -> Result<PathBuf> {
     Ok(data_dir()?.join("venv"))
 }
 
-/// Write both config files. Creates directories as needed.
-pub fn write_configs(inputs: &UserInputs, tokens: &SharedTokens) -> Result<()> {
+pub fn write_configs(inputs: &UserInputs, tokens: &SharedTokens, env: &Environment) -> Result<()> {
     let cfg_dir = config_dir()?;
     std::fs::create_dir_all(&cfg_dir)
         .with_context(|| format!("Failed to create config directory: {}", cfg_dir.display()))?;
 
     write_gateway_config(inputs, tokens)?;
-    write_dot_env(inputs, tokens)?;
+    write_dot_env(inputs, tokens, env)?;
 
     Ok(())
 }
@@ -137,8 +137,7 @@ fn write_gateway_config(inputs: &UserInputs, tokens: &SharedTokens) -> Result<()
     Ok(())
 }
 
-/// Write `~/.config/plit/.env`.
-fn write_dot_env(inputs: &UserInputs, tokens: &SharedTokens) -> Result<()> {
+fn write_dot_env(inputs: &UserInputs, tokens: &SharedTokens, env: &Environment) -> Result<()> {
     let data = data_dir()?;
     let db_path = data.join("pipelit.db");
     let secret_key = uuid::Uuid::new_v4().to_string();
@@ -151,6 +150,9 @@ SECRET_KEY={secret_key}
 DEBUG=false
 ALLOWED_HOSTS=localhost,127.0.0.1
 
+# Sandbox
+SANDBOX_MODE={sandbox_mode}
+
 # Gateway integration
 GATEWAY_ENABLED=true
 GATEWAY_URL=http://localhost:{gw_port}
@@ -160,6 +162,7 @@ GATEWAY_INBOUND_TOKEN={inbound_token}
 ",
         db_path = db_path.display(),
         secret_key = secret_key,
+        sandbox_mode = env.sandbox_mode,
         gw_port = inputs.gateway_port,
         admin_token = tokens.admin_token,
         send_token = tokens.send_token,

--- a/crates/plit/src/commands/init/mod.rs
+++ b/crates/plit/src/commands/init/mod.rs
@@ -48,7 +48,7 @@ pub async fn run() -> Result<()> {
     // 2. Check prerequisites
     // -----------------------------------------------------------------------
     output::status("Checking prerequisites...");
-    prereqs::check_all()?;
+    let env = prereqs::check_all()?;
     output::status("");
 
     // -----------------------------------------------------------------------
@@ -96,7 +96,7 @@ pub async fn run() -> Result<()> {
     // 6. Write config files (.env first — needed for migrations)
     // -----------------------------------------------------------------------
     output::status("Writing configuration files...");
-    config::write_configs(&inputs, &shared_tokens)?;
+    config::write_configs(&inputs, &shared_tokens, &env)?;
     output::status("");
 
     // -----------------------------------------------------------------------

--- a/crates/plit/src/commands/init/prereqs.rs
+++ b/crates/plit/src/commands/init/prereqs.rs
@@ -1,15 +1,19 @@
 //! Prerequisite checking for `plit init`.
 //!
-//! Verifies that required external tools (python3, pip3, redis-server, git)
-//! are available on PATH and captures their versions.
+//! Verifies that required external tools are available on PATH,
+//! detects container environments, and determines sandbox mode.
 
+use std::path::Path;
 use std::process::Command;
 
 use anyhow::{Result, bail};
 
 use crate::output;
 
-/// Result of a single prerequisite check.
+pub struct Environment {
+    pub sandbox_mode: String,
+}
+
 struct PrereqResult {
     name: &'static str,
     found: bool,
@@ -17,10 +21,15 @@ struct PrereqResult {
     install_hint: &'static str,
 }
 
-/// Check all prerequisites. Returns `Ok(())` if all are present, or an error
-/// with actionable instructions for missing tools.
-pub fn check_all() -> Result<()> {
-    let checks = vec![
+pub fn check_all() -> Result<Environment> {
+    let container = detect_container();
+    let in_container = container.is_some();
+
+    if let Some(ref ctype) = container {
+        output::status(&format!("  ✓ container detected ({})", ctype));
+    }
+
+    let mut checks = vec![
         check_binary(
             "python3",
             &["--version"],
@@ -44,6 +53,14 @@ pub fn check_all() -> Result<()> {
         ),
     ];
 
+    if !in_container {
+        checks.push(check_binary(
+            "bwrap",
+            &["--version"],
+            "Install bubblewrap: `sudo apt install bubblewrap` or build from source",
+        ));
+    }
+
     let mut any_missing = false;
 
     for result in &checks {
@@ -66,7 +83,40 @@ pub fn check_all() -> Result<()> {
         bail!("Missing required prerequisites. Install them and re-run `plit init`.");
     }
 
-    Ok(())
+    let sandbox_mode = if in_container {
+        "container".to_string()
+    } else {
+        "bwrap".to_string()
+    };
+
+    Ok(Environment { sandbox_mode })
+}
+
+fn detect_container() -> Option<String> {
+    if std::env::var("CODESPACES").ok().as_deref() == Some("true") {
+        return Some("codespaces".to_string());
+    }
+    if std::env::var("GITPOD_WORKSPACE_ID").is_ok() {
+        return Some("gitpod".to_string());
+    }
+    if Path::new("/.dockerenv").exists() {
+        return Some("docker".to_string());
+    }
+    if std::env::var("container").ok().as_deref() == Some("podman") {
+        return Some("podman".to_string());
+    }
+    if let Ok(cgroup) = std::fs::read_to_string("/proc/1/cgroup") {
+        if cgroup.contains("docker") {
+            return Some("docker".to_string());
+        }
+        if cgroup.contains("kubepods") {
+            return Some("kubernetes".to_string());
+        }
+        if cgroup.contains("containerd") {
+            return Some("containerd".to_string());
+        }
+    }
+    None
 }
 
 /// Check if a binary is available and capture its version string.


### PR DESCRIPTION
## Summary

Adds container/sandbox environment detection to `plit init` so the generated Pipelit config correctly sets `SANDBOX_MODE`.

## What changed

- **Container detection** in prereqs — checks `/.dockerenv`, `CODESPACES`, `GITPOD_WORKSPACE_ID`, `container=podman`, `/proc/1/cgroup` patterns
- **Conditional bwrap check** — if in a container, bwrap is skipped (not needed). If on bare metal, bwrap is required (hard-fail if missing).
- **SANDBOX_MODE in .env** — writes `SANDBOX_MODE=container` or `SANDBOX_MODE=bwrap` to the generated Pipelit `.env`

## Behavior

| Environment | bwrap check | SANDBOX_MODE |
|-------------|-------------|--------------|
| Bare metal / VM | Required | `bwrap` |
| Docker / Podman | Skipped | `container` |
| Codespaces / Gitpod | Skipped | `container` |
| Kubernetes | Skipped | `container` |

## Files changed (3)

- `prereqs.rs` — `detect_container()` + conditional bwrap in `check_all()`, returns `Environment`
- `config.rs` — `write_dot_env` accepts `Environment`, writes `SANDBOX_MODE`
- `mod.rs` — threads `env` from prereqs through to config generation